### PR TITLE
mod no permisson file exec exit status 127->126

### DIFF
--- a/src/exec/path_check.c
+++ b/src/exec/path_check.c
@@ -19,7 +19,7 @@ static char	*do_file_access(char *file)
 	else
 	{
 		perror("file");
-		exit(127);
+		exit(126);
 	}
 }
 


### PR DESCRIPTION
パーミッションエラーでコマンドが実行できない時の終了ステータスを127から126に変更
