### PR TITLE
mod change_environ_to_map init PWD and OLDPWD

### DIFF
--- a/include/environ_control.h
+++ b/include/environ_control.h
@@ -15,7 +15,7 @@
 
 # include "define.h"
 
-t_env	**change_environ_to_map(const char **environ);
+t_env	**change_environ_to_map(const char **environ, char *crr_dir);
 char	**change_map_to_environ(t_env **map, bool *err_flag);
 
 t_env	*select_env(t_env **map, const char *env_name);

--- a/main.c
+++ b/main.c
@@ -66,10 +66,12 @@ int	main(int argc, char **argv, const char **envp)
 	signal(SIGINT, minishell_handler);
 	signal(SIGQUIT, SIG_IGN);
 	rl_event_hook = heredoc_handler;
-	data.crr_dir = getcwd(NULL, 0);
-	data.env_map = change_environ_to_map(envp, data.crr_dir);
 	data.err_code = 0;
 	data.err_flag = false;
+	data.crr_dir = getcwd(NULL, 0);
+	data.env_map = change_environ_to_map(envp, data.crr_dir);
+	if (data.env_map == NULL)
+		data.err_code = 1;
 	exec_shell_loop(&data);
 	free_all_data(&data);
 	ft_putendl_fd("exit", STDERR_FILENO);

--- a/main.c
+++ b/main.c
@@ -66,8 +66,8 @@ int	main(int argc, char **argv, const char **envp)
 	signal(SIGINT, minishell_handler);
 	signal(SIGQUIT, SIG_IGN);
 	rl_event_hook = heredoc_handler;
-	data.env_map = change_environ_to_map(envp);
 	data.crr_dir = getcwd(NULL, 0);
+	data.env_map = change_environ_to_map(envp, data.crr_dir);
 	data.err_code = 0;
 	data.err_flag = false;
 	exec_shell_loop(&data);

--- a/src/builtin/cd.c
+++ b/src/builtin/cd.c
@@ -12,6 +12,23 @@
 
 #include "../../include/minishell.h"
 
+static void	update_oldpwd(t_env **map)
+{
+	t_env	*env_pwd;
+	t_env	*env_oldpwd;
+
+	if (map == NULL)
+		return ;
+	env_pwd = select_env(map, "PWD");
+	env_oldpwd = select_env(map, "OLDPWD");
+	if (env_oldpwd == NULL)
+		return ;
+	else if (env_pwd == NULL || env_pwd->value == NULL)
+		env_oldpwd->value = free_str(env_oldpwd->value);
+	else
+		update_env(map, "OLDPWD", env_pwd->value);
+}
+
 static void	change_pwd_oldpwd_crrdir(t_data *data, char *str)
 {
 	char	*new_crr_dir;
@@ -22,6 +39,7 @@ static void	change_pwd_oldpwd_crrdir(t_data *data, char *str)
 		err_no_cd_file("", &data->err_code);
 	else
 	{
+		update_oldpwd(data->env_map);
 		update_env(data->env_map, "OLDPWD", data->crr_dir);
 		if (new_crr_dir == NULL)
 		{

--- a/src/environ_control/change_environ_to_map.c
+++ b/src/environ_control/change_environ_to_map.c
@@ -12,38 +12,46 @@
 
 #include "../../include/minishell.h"
 
-static void	curd_oldpwd(t_env **map)
+static bool	curd_oldpwd(t_env **map)
 {
 	t_env	*env_pwd;
+	char	*oldpwd;
 
 	env_pwd = select_env(map, "OLDPWD");
 	if (env_pwd == NULL)
-		insert_env_to_env_map(map, ft_strdup("OLDPWD"));
+	{
+		oldpwd = ft_strdup("OLDPWD");
+		if (oldpwd == NULL)
+			return (true);
+		else if (insert_env_to_env_map(map, oldpwd) == NULL)
+			return (true);
+	}
 	else if (env_pwd->value == NULL)
 		;
 	else if (access(env_pwd->value, X_OK) != 0)
 		env_pwd->value = free_str(env_pwd->value);
-	else
-		return ;
+	return (false);
 }
 
-static void	curd_pwd(t_env **map, char *crr_dir)
+static bool	curd_pwd(t_env **map, char *crr_dir)
 {
 	t_env	*env_pwd;
 	char	*original_pwd;
 
 	if (crr_dir == NULL)
-		return ;
+		return (true);
 	env_pwd = select_env(map, "PWD");
 	if (env_pwd == NULL)
 	{
 		original_pwd = ft_strjoin("PWD=", crr_dir);
 		if (original_pwd == NULL)
-			return ;
-		insert_env_to_env_map(map, original_pwd);
+			return (true);
+		else if (insert_env_to_env_map(map, original_pwd))
+			return (true);
 	}
 	else
 		update_env(map, "PWD", crr_dir);
+	return (false);
 }
 
 t_env	**change_environ_to_map(const char **environ, char *crr_dir)
@@ -62,7 +70,7 @@ t_env	**change_environ_to_map(const char **environ, char *crr_dir)
 		if (insert_env_to_env_map(map, ft_strdup(environ[idx++])) == NULL)
 			return (free_hash_map(map));
 	}
-	curd_oldpwd(map);
-	curd_pwd(map, crr_dir);
+	if (curd_oldpwd(map) || curd_pwd(map, crr_dir))
+		return (free_hash_map(map));
 	return (map);
 }

--- a/src/environ_control/change_environ_to_map.c
+++ b/src/environ_control/change_environ_to_map.c
@@ -12,7 +12,41 @@
 
 #include "../../include/minishell.h"
 
-t_env	**change_environ_to_map(const char **environ)
+static void	curd_oldpwd(t_env **map)
+{
+	t_env	*env_pwd;
+
+	env_pwd = select_env(map, "OLDPWD");
+	if (env_pwd == NULL)
+		insert_env_to_env_map(map, ft_strdup("OLDPWD"));
+	else if (env_pwd->value == NULL)
+		;
+	else if (access(env_pwd->value, X_OK) != 0)
+		env_pwd->value = free_str(env_pwd->value);
+	else
+		return ;
+}
+
+static void	curd_pwd(t_env **map, char *crr_dir)
+{
+	t_env	*env_pwd;
+	char	*original_pwd;
+
+	if (crr_dir == NULL)
+		return ;
+	env_pwd = select_env(map, "PWD");
+	if (env_pwd == NULL)
+	{
+		original_pwd = ft_strjoin("PWD=", crr_dir);
+		if (original_pwd == NULL)
+			return ;
+		insert_env_to_env_map(map, original_pwd);
+	}
+	else
+		update_env(map, "PWD", crr_dir);
+}
+
+t_env	**change_environ_to_map(const char **environ, char *crr_dir)
 {
 	t_env	**map;
 	size_t	idx;
@@ -28,5 +62,7 @@ t_env	**change_environ_to_map(const char **environ)
 		if (insert_env_to_env_map(map, ft_strdup(environ[idx++])) == NULL)
 			return (free_hash_map(map));
 	}
+	curd_oldpwd(map);
+	curd_pwd(map, crr_dir);
 	return (map);
 }

--- a/src/exec/path_check.c
+++ b/src/exec/path_check.c
@@ -61,5 +61,10 @@ char	*get_path(char *separgv, t_data *data)
 		err_no_file(separgv, &data->err_code);
 		exit (127);
 	}
+	else if (env_path->value[0] == '\0')
+	{
+		err_no_file(separgv, &data->err_code);
+		exit (127);
+	}
 	return (check_access(env_path->value, separgv));
 }

--- a/src/expansion/variable_expansion.c
+++ b/src/expansion/variable_expansion.c
@@ -75,6 +75,9 @@ void	variable_expansion(t_words *words, t_data *data)
 			words = words->next;
 		}
 		else
+		{
 			words->word = replace_dallor_str_to_env(words->word, target, data);
+			words = words->next;
+		}
 	}
 }

--- a/src/utils/dup2_and_close.c
+++ b/src/utils/dup2_and_close.c
@@ -34,5 +34,5 @@ void	dup2_and_close_stdout(int fd, bool exit_flag, bool *err_flag)
 	{
 		do_dup2(fd, STDOUT_FILENO, exit_flag, err_flag);
 		do_close(fd, exit_flag, err_flag);
-}
 	}
+}


### PR DESCRIPTION
minishell立ち上げ時に、PWD, OLDPWDがセットされていない時や値が間違っている時に正しい初期化処理を入れた