### PR TITLE
catやsleep中のCTRL+\の挙動の修正とheredoc中の変数展開の挙動の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 NAME			=	minishell
 CC				=	cc
 RM				=	rm -f
-CFLAGS			=	-Wall -Wextra -Werror -g
+CFLAGS			=	-Wall -Wextra -Werror
 READLINE_INFO	=	$(shell brew --prefix readline)
 READLINE_INC	=	-I $(READLINE_INFO)/include
 READLINE_LIB	=	-L $(READLINE_INFO)/lib -lreadline
@@ -61,6 +61,7 @@ SRCS			=	main.c \
 					$(EXPANTION_DIR)replace.c \
 					$(EXPANTION_DIR)is_assignment_pattern.c \
 					$(EXPANTION_DIR)is_do_not_word_split_pattern.c \
+					$(EXPANTION_DIR)replace_all_env.c \
 					$(LIBFT_DIR)ft_atoi.c \
 					$(LIBFT_DIR)ft_calloc.c \
 					$(LIBFT_DIR)ft_isalnum.c \

--- a/include/define.h
+++ b/include/define.h
@@ -40,6 +40,7 @@
 # define ERR_GETCWD ": getcwd: cannot access parent directories"
 # define WARN_HEREDOC "warning: heredoc delimited by end-of-file (wanted `"
 # define WARN_HEREDOC_CLOSE "')"
+# define ERR_CORE_DUMPED "Quit (core dumped)"
 
 # include <sys/wait.h>
 # include <sys/stat.h>
@@ -85,6 +86,7 @@ enum e_sig_mode
 	HEREDOC_MODE,
 	HEREDOC_C_MODE,
 	EXEC_MODE,
+	EXEC_C_MODE,
 };
 
 typedef enum e_token_type

--- a/include/utils.h
+++ b/include/utils.h
@@ -87,7 +87,9 @@ void			dup2_and_close_stdin(int fd, bool exit_flag, bool *err_flag);
 void			dup2_and_close_pipefd(int *fd, bool exit_flag, bool *err_flag);
 void			dup2_and_close_stdout(int fd, bool exit_flag, bool *err_flag);
 
-void			minishell_handler(int signal);
+void			print_core_dumped(int wstatus);
+void			sig_int_handler(int signal);
+void			sig_quit_handler(int signal);
 int				heredoc_handler(void);
 
 char			*strjoin_path(char *sepflag, char *separgv);

--- a/include/utils.h
+++ b/include/utils.h
@@ -32,6 +32,7 @@ bool			is_c_in_str(const char *str, int c);
 
 char			*strdup_n(const char *src, size_t n);
 char			*strdup_env(const char *str, bool *err_flag);
+char			*strdup_env_ignore_quote(const char *str, bool *err_flag);
 
 t_words			*new_word_node(const char *str);
 t_words			*new_word_node_n(const char *str, size_t n, bool flag);
@@ -65,6 +66,7 @@ t_token_type	get_quote_type(int c);
 t_token_type	get_delimiter_type(const char *str);
 t_words			*get_next_start_word(t_words *words);
 const char		*get_env_position(const char *str);
+const char		*get_env_position_ignore_quote(const char *str);
 
 t_words			*append_word_node(t_words *list, t_words *word_node);
 t_words			*append_with_flag(t_words *list, t_words *node, bool err_flag);

--- a/main.c
+++ b/main.c
@@ -14,7 +14,7 @@
 
 volatile sig_atomic_t	g_sig_mode;
 
-void	exec_command_line(const char *line, t_data *data)
+static void	exec_command_line(const char *line, t_data *data)
 {
 	t_tree_node	*root;
 
@@ -35,7 +35,7 @@ void	exec_command_line(const char *line, t_data *data)
 	free_all_tree_node(root);
 }
 
-void	exec_shell_loop(t_data *data)
+static void	exec_shell_loop(t_data *data)
 {
 	char	*line;
 

--- a/main.c
+++ b/main.c
@@ -63,7 +63,7 @@ int	main(int argc, char **argv, const char **envp)
 	(void)argc;
 	(void)argv;
 	g_sig_mode = NORMAL_MODE;
-	signal(SIGINT, minishell_handler);
+	signal(SIGINT, sig_int_handler);
 	signal(SIGQUIT, SIG_IGN);
 	rl_event_hook = heredoc_handler;
 	data.err_code = 0;

--- a/src/exec/child_wait.c
+++ b/src/exec/child_wait.c
@@ -22,8 +22,10 @@ static int	change_wstatus_to_err_code(int wstatus)
 {
 	if (WIFEXITED(wstatus))
 		return (WEXITSTATUS(wstatus));
-	else
+	else if (WIFSIGNALED(wstatus))
 		return (128 + WTERMSIG(wstatus));
+	else
+		return (WEXITSTATUS(wstatus));
 }
 
 void	child_wait(t_tree_node *first_cmd, t_table *table, t_data *data)
@@ -40,6 +42,8 @@ void	child_wait(t_tree_node *first_cmd, t_table *table, t_data *data)
 		{
 			do_waitpid(table[idx++].pid, &wstatus, 0);
 			data->err_code = change_wstatus_to_err_code(wstatus);
+			if (g_sig_mode == EXEC_C_MODE && WIFSIGNALED(wstatus))
+				print_core_dumped(wstatus);
 			break ;
 		}
 		else

--- a/src/exec/cmd_loop.c
+++ b/src/exec/cmd_loop.c
@@ -29,9 +29,11 @@ void	cmd_loop(t_tree_node *root, t_data *data)
 		return ;
 	}
 	g_sig_mode = EXEC_MODE;
+	signal(SIGQUIT, sig_quit_handler);
 	if (is_builtin_cmd_alone_without_env(root))
 		do_builtin_cmd_alone_without_env(root, data);
 	else
 		do_normal_cmd(root, prevfd, table, data);
 	free_table(table);
+	signal(SIGQUIT, SIG_IGN);
 }

--- a/src/expansion/replace_all_env.c
+++ b/src/expansion/replace_all_env.c
@@ -1,0 +1,73 @@
+#include "../../include/minishell.h"
+
+static char	*new_new_word_ignore(char *str, char *target, const char *new_word)
+{
+	size_t		new_str_size;
+	char		*new_str;
+	const char	*env_position;
+
+	new_str_size = ft_strlen(str) + ft_strlen(new_word) - ft_strlen(target);
+	new_str = (char *)ft_calloc(sizeof(char), (new_str_size));
+	if (new_str == NULL)
+		return (NULL);
+	env_position = get_env_position_ignore_quote(str);
+	ft_strlcat(new_str, str, (env_position - str + 1));
+	ft_strcat(new_str, new_word);
+	env_position += (ft_strlen(target) + 1);
+	ft_strcat(new_str, env_position);
+	return (new_str);
+}
+
+static char	*replace_ignore(char *str, char *target, const char *new_word)
+{
+	char	*new_str;
+
+	new_str = new_new_word_ignore(str, target, new_word);
+	free_str(str);
+	free_str(target);
+	return (new_str);
+}
+
+static char	*replace_dallor_ignore_quote(char *word, char *target, t_data *d)
+{
+	t_env	*env;
+	char	*str_err_code;
+	char	*new_str;
+
+	env = select_env(d->env_map, target);
+	new_str = NULL;
+	if (*target == '?')
+	{
+		str_err_code = ft_itoa(d->err_code);
+		if (str_err_code != NULL)
+			new_str = replace_ignore(word, target, str_err_code);
+		else
+			free_double_str(word, target);
+		free_str(str_err_code);
+	}
+	else if (env == NULL)
+		new_str = replace_ignore(word, target, "");
+	else
+		new_str = replace_ignore(word, target, env->value);
+	if (new_str == NULL)
+		d->err_flag = true;
+	return (new_str);
+}
+
+char	*replace_all_env(char *line, t_token_type type, t_data *data)
+{
+	char	*target;
+
+	if (type == DELIMITER_QUOTE)
+		return (line);
+	target = strdup_env_ignore_quote(line, &data->err_flag);
+	while (target != NULL && data->err_flag == false)
+	{
+		line = replace_dallor_ignore_quote(line, target, data);
+		target = strdup_env_ignore_quote(line, &data->err_flag);
+	}
+	if (data->err_flag)
+		return (free_str(line));
+	return (line);
+}
+

--- a/src/expansion/variable_expansion.c
+++ b/src/expansion/variable_expansion.c
@@ -38,23 +38,6 @@ static char	*replace_dallor_str_to_env(char *word, char *target, t_data *data)
 	return (new_str);
 }
 
-char	*replace_all_env(char *line, t_token_type type, t_data *data)
-{
-	char	*target;
-
-	if (type == DELIMITER_QUOTE)
-		return (line);
-	target = strdup_env(line, &data->err_flag);
-	while (target != NULL && data->err_flag == false)
-	{
-		line = replace_dallor_str_to_env(line, target, data);
-		target = strdup_env(line, &data->err_flag);
-	}
-	if (data->err_flag)
-		return (free_str(line));
-	return (line);
-}
-
 void	variable_expansion(t_words *words, t_data *data)
 {
 	int		quote_mode;

--- a/src/utils/get_env_position.c
+++ b/src/utils/get_env_position.c
@@ -35,6 +35,20 @@ static const char	*skip_to_next_quote_or_dallor_prev_char(const char *str)
 	return (str);
 }
 
+const char	*get_env_position_ignore_quote(const char *str)
+{
+	while (*str != '\0')
+	{
+		if (*str == '$')
+		{
+			if (is_deal_target(str))
+				break ;
+		}
+		str++;
+	}
+	return (str);
+}
+
 const char	*get_env_position(const char *str)
 {
 	bool	single_quote_flag;

--- a/src/utils/signal.c
+++ b/src/utils/signal.c
@@ -12,11 +12,10 @@
 
 #include "../../include/minishell.h"
 
-void	minishell_handler(int signal)
+void	sig_int_handler(int signal)
 {
-	if (signal != SIGINT)
-		return ;
-	else if (g_sig_mode == HEREDOC_MODE || g_sig_mode == HEREDOC_C_MODE)
+	(void)signal;
+	if (g_sig_mode == HEREDOC_MODE || g_sig_mode == HEREDOC_C_MODE)
 		g_sig_mode = HEREDOC_C_MODE;
 	else if (g_sig_mode == EXEC_MODE)
 		ft_putchar_fd('\n', STDOUT_FILENO);
@@ -28,6 +27,19 @@ void	minishell_handler(int signal)
 		rl_replace_line("", 0);
 		rl_redisplay();
 	}
+}
+
+void	print_core_dumped(int wstatus)
+{
+	if (WCOREDUMP(wstatus))
+		ft_putendl_fd(ERR_CORE_DUMPED, STDERR_FILENO);
+}
+
+void	sig_quit_handler(int signal)
+{
+	(void)signal;
+	if (g_sig_mode == EXEC_MODE)
+		g_sig_mode = EXEC_C_MODE;
 }
 
 int	heredoc_handler(void)

--- a/src/utils/utils_strdup.c
+++ b/src/utils/utils_strdup.c
@@ -32,6 +32,22 @@ char	*strdup_n(const char *src, size_t n)
 	return (dest);
 }
 
+char	*strdup_env_ignore_quote(const char *str, bool *err_flag)
+{
+	const char	*env_position;
+	char		*env;
+
+	if (str == NULL)
+		return (NULL);
+	env_position = get_env_position_ignore_quote(str);
+	if (*env_position == '\0')
+		return (NULL);
+	env = strdup_n(&env_position[1], count_env_size(env_position));
+	if (env == NULL)
+		return (reverse_flag(err_flag));
+	return (env);
+}
+
 char	*strdup_env(const char *str, bool *err_flag)
 {
 	const char	*env_position;


### PR DESCRIPTION
catやsleep等のコマンド自体が標準入力待ちになるようなコマンドで標準入力まちのときにCTRL+\が押された時に、親プロセスで
Quit (core dumped)を出力。
最後のコマンドが標準入力まちになるものでない場合は何もしない。
ヒアドク中にシングルクォーテーションで囲われた文字、
例えば、'$SHELL'が入力された時、変数展開していなかったので修正。